### PR TITLE
Use flexible array member for DNS packet records

### DIFF
--- a/src/pkt.h
+++ b/src/pkt.h
@@ -427,7 +427,7 @@ struct dns_packet_t { /* From RFC 1035 */
   uint16_t ancount; /* 16 bit: Number of answer records */
   uint16_t nscount; /* 16 bit: Number of name servers */
   uint16_t arcount; /* 16 bit: Number of additional records */
-  uint8_t  records[PKT_IP_PLEN];
+  uint8_t  records[];
 } __attribute__((packed));
 
 struct pkt_dot1xhdr_t {


### PR DESCRIPTION
## Summary
- avoid array-bounds warnings in DHCP DNS handling by turning `struct dns_packet_t`'s record storage into a flexible array

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `make check` *(fails: No rule to make target 'check')*
- `gcc -std=gnu11 -Wall -c src/dhcp.c -I src -I .` *(fails: fatal error: config.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae88d2f97c832d9167441c29078c1e